### PR TITLE
Expose webserver as a package in the flake outputs

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,23 @@
 {
   "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1726560853,
+        "narHash": "sha256-X6rJYSESBVr3hBoH0WbKE5KvhPU5bloyZ2L4K60/fPQ=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "c1dfcf08411b08f6b8615f7d8971a2bfa81d5e8a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
     "garnix-lib": {
       "inputs": {
         "nixpkgs": [
@@ -38,8 +56,24 @@
     },
     "root": {
       "inputs": {
+        "flake-utils": "flake-utils",
         "garnix-lib": "garnix-lib",
         "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -36,7 +36,7 @@
               githubRepo = "nixcon-2024-player-template";
               # The nix derivation that will be used as the server process. It
               # should open a webserver on port 8080.
-              webserver = self.packages.${system}.web-server;
+              webserver = self.packages.${system}.webserver;
               # If you want to log in to your deployed server, put your SSH key
               # here:
               sshKey = "<YOUR_PUBLIC_SSH_KEY>";

--- a/flake.nix
+++ b/flake.nix
@@ -3,6 +3,8 @@
 
   inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
 
+  inputs.flake-utils.url = "github:numtide/flake-utils";
+
   inputs.garnix-lib = {
     url = "github:garnix-io/garnix-lib";
     inputs = {
@@ -10,16 +12,16 @@
     };
   };
 
-  outputs =
-    {
-      self,
-      nixpkgs,
-      garnix-lib,
-      ...
-    }:
+  outputs = { self, nixpkgs, garnix-lib, flake-utils }:
     let
       system = "x86_64-linux";
     in
+    (flake-utils.lib.eachSystem [ "x86_64-linux" ] (system:
+      let pkgs = import nixpkgs { inherit system; };
+      in {
+        packages.webserver = pkgs.hello;
+      }))
+    //
     {
       nixosConfigurations.server = nixpkgs.lib.nixosSystem {
         inherit system;
@@ -32,8 +34,9 @@
               githubLogin = "GITHUB_USER";
               # You only need to change this if you changed the forked repo name.
               githubRepo = "nixcon-2024-player-template";
-              # The nix derivation that will be used as the server process. It should open a webserver on port 8080.
-              webserver = pkgs.hello;
+              # The nix derivation that will be used as the server process. It
+              # should open a webserver on port 8080.
+              webserver = self.packages.${system}.web-server;
               # If you want to log in to your deployed server, put your SSH key
               # here:
               sshKey = "<YOUR_PUBLIC_SSH_KEY>";

--- a/flake.nix
+++ b/flake.nix
@@ -18,8 +18,11 @@
     in
     (flake-utils.lib.eachSystem [ "x86_64-linux" ] (system:
       let pkgs = import nixpkgs { inherit system; };
-      in {
-        packages.webserver = pkgs.hello;
+      in rec {
+        packages = {
+          webserver = pkgs.hello;
+          default = packages.webserver;
+        };
       }))
     //
     {


### PR DESCRIPTION
Fixes https://github.com/garnix-io/garnix/issues/1866.
