### PR TITLE
Add module to the flake output

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -44,7 +44,7 @@
         inherit system;
         modules = [
           garnix-lib.nixosModules.garnix
-          ./nixcon-garnix-player-module.nix
+          self.nixosModules.nixcon-garnix-player-module
           ({ pkgs, ... }: {
             playerConfig = {
               # Your github user:
@@ -62,6 +62,9 @@
           })
         ];
       };
+
+      nixosModules.nixcon-garnix-player-module = ./nixcon-garnix-player-module.nix;
+      nixosModules.default = self.nixosModules.nixcon-garnix-player-module;
 
       # Remove before starting the workshop - this is just for development
       checks = import ./checks.nix { inherit nixpkgs self; };

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -12,7 +12,7 @@
       {
         imports = [
           flake.inputs.garnix-lib.nixosModules.garnix
-          ../nixcon-garnix-player-module.nix
+          flake.nixosModules.nixcon-garnix-player-module
         ];
 
         garnix.server.isVM = true;


### PR DESCRIPTION
We add the module to the flake output so that it could be used in other flakes.
