### PR TITLE
Wait for network to be up before starting the webserver service

### DIFF
--- a/nixcon-garnix-player-module.nix
+++ b/nixcon-garnix-player-module.nix
@@ -40,7 +40,7 @@ in
 
   config = {
     systemd.services.webserver = {
-      after = [ "network.target" ];
+      after = [ "network-online.target" ];
       wantedBy = [ "multi-user.target" ];
       description = "The player webserver service";
       script = lib.getExe cfg.webserver;


### PR DESCRIPTION
We still rely on dhcp which can take a while to get an IP address.
