### PR TITLE
DHCP is slow, retry registration 10 times instead of 3

### DIFF
--- a/nixcon-garnix-player-module.nix
+++ b/nixcon-garnix-player-module.nix
@@ -40,7 +40,7 @@ in
 
   config = {
     systemd.services.webserver = {
-      after = [ "network-online.target" ];
+      after = [ "network.target" ];
       wantedBy = [ "multi-user.target" ];
       description = "The player webserver service";
       script = lib.getExe cfg.webserver;

--- a/nixcon-garnix-player-module.nix
+++ b/nixcon-garnix-player-module.nix
@@ -49,7 +49,7 @@ in
       };
       serviceConfig = {
         DynamicUser = true;
-        ExecStartPre = "${lib.getExe pkgs.curl} -v --retry 3 --retry-delay 0 --retry-all-errors --fail -X POST ${cfg.gameServerUrl}/register/${cfg.githubLogin}/${cfg.githubRepo}";
+        ExecStartPre = "${lib.getExe pkgs.curl} -v --retry 10 --retry-delay 0 --retry-all-errors --fail -X POST ${cfg.gameServerUrl}/register/${cfg.githubLogin}/${cfg.githubRepo}";
       };
     };
 


### PR DESCRIPTION
The previous change didn't help as the `network-online.target` state is not
changed when we deploy the player nixos configuration on top of the
existing nixos configuration.
